### PR TITLE
edits to add output directory prefix to NM + MH edits to usage/options

### DIFF
--- a/batch_coproseq.pl
+++ b/batch_coproseq.pl
@@ -48,7 +48,7 @@ my $genomesdir = "genomes";
 my $summariesdir = "summaries";
 my $GEOdir = "GEO";
 my $squashedgenomesdir = "genomes/squashed";
-my $project_data_path = "project.info";
+my $project_data_path = "";
 #my $getdata_file_path = "getdata.sh";
 my $align_file_path = "align.sh";
 my $cleanup_file_path = "cleanup.sh";
@@ -64,14 +64,15 @@ my $mismatches_allowed = 0;
 my $readsize = 25;	# Length AFTER trimming off barcode
 
 GetOptions(
-	"a|allfiles"				=> \$allfiles,
+#MCH#	"a|allfiles"				=> \$allfiles,
 	"e|errors=i"				=> \$mismatches_allowed,
 	"g|group=s"					=> \$group,
 	"G|GEO"						=> \$GEO,
 	"i|igs=s"					=> \$IGS_table_file,
-	"k|key=s"					=> \$google_key,
+#MCH#	"k|key=s"					=> \$google_key,
 	'l|length=i'				=> \$readsize,
 	"m|mapping=s"				=> \$mapping_file_path,
+	"p|project=s"				=> \$project_data_path,
 	# ncbi option below is NOT working for draft genomes
 	"n|ncbi"					=> \$ncbi,
 	"o|output=s"				=> \$basedir,
@@ -391,7 +392,7 @@ sub make_align_file {
 	open (ALIGNFILE, ">$filepath") || die "ERROR: Can't open $filepath!\n";
 	for my $p (@$spreadsheet_hash) {
 		my $prefix = $p->{machine}.'_'.$p->{run}.'_'.$p->{lane};
-		print ALIGNFILE "perl $coproseq_script_path -i $prefix.seq -b $prefix.bc -g $basedir/genomes/squashed" .
+		print ALIGNFILE "perl $coproseq_script_path -i $prefix.seq -b $prefix.bc -g genomes/squashed" .
 						" -p $prefix -m $mismatches_allowed -o $basedir -n $IGS_PATH -t -l " . ($readsize+$$bclengths_hash_ref{$p->{pool}}) . 
 						$cpu."\n";
 	}
@@ -809,21 +810,20 @@ sub fancy_title {
 }
 
 sub usage {
-	my $error = shift;
-	print "$error\n" if $error;
-	print 	"Usage: perl batch_coproseq.pl -g <analysis group(s)> -m <mapping file>\n",
-			"\t-e Number of errors/mismatches to allow in alignment (0-2)\n",
-			"\t-g Code(s) specifying the analysis groups (defined in Google Spreadsheet) you want to include in this analysis\n",
-			"\t-i IGS table file (optional)\n",
-			"\t-k Google spreadsheet key for specifying spreadsheets other than the default\n",
-			"\t-l Length of read (after trimming barcode) to use in alignment\n",
-			"\t-m Mapping file specifying the barcode associated with each sample in your analysis\n",
-			"\t-ncbi Specifies that genome files should be downloaded from the NCBI web server, rather than microbialomics\n",
-			"\t-p Google spreadsheet page/ID for specifying sheets other than the first in a multi-page spreadsheet; 1st page by default (i.e. -i 0)\n",
-			"\n";
-	exit(1);
+        my $error = shift;
+        print "$error\n" if $error;
+        print   "Usage: perl batch_coproseq.pl -g <analysis group(s)> -m <mapping file> -p <project file>\n",
+                        "\t-e Number of errors/mismatches to allow in ELAND alignment (0-2)\n",
+                        "\t-g Code(s) specifying the analysis groups (defined in your project file) you want to include in this analysis\n",
+                        "\t-i IGS table file (optional)\n",
+                        "\t-k Google spreadsheet key for specifying spreadsheets other than the default\n",
+                        "\t-l Length of read (after trimming barcode) to use in alignment (default is 25)\n",
+                        "\t-m Mapping file specifying the barcode associated with each sample in your analysis\n",
+                        "\t-p File specifying the project data associated with each analysis group (formerly \"project.info\")\n",
+                        "\t-ncbi Specifies that genome files should be downloaded from the NCBI web server\n",
+                        "\n";
+        exit(1);
 }
-
 
 # Takes any run number from the Google spreadsheet of 4 digits or less, 
 # excluding any decimals specifying run version numbers, and converts it to the

--- a/coproseq.pl
+++ b/coproseq.pl
@@ -122,28 +122,28 @@ sub make_alignment_jobs_file {
 			# Align to microbial references
 				"$eland_executables_folder$elandtype $outputdir\/bcsortedseqs\/$prefix\_$_\.fas $genomesdir $outputdir\/elandresults\/$prefix\_$_\.elandout\n",
 			# Pass sequences that did not align to microbial references to a new file (use as input for alignment to adapters)
-				"$parse_script_path $outputdir\/elandresults\/$prefix\_$_\.elandout NM\/$prefix\_$_\_norefs.NM\n",
+				"$parse_script_path $outputdir\/elandresults\/$prefix\_$_\.elandout $outputdir\/NM\/$prefix\_$_\_norefs.NM\n",
 			# Align remaining sequences to adapter reference, allowing 2 mismatches
 			# Squashed adapter genome should be distributed with scripts
-				"$eland_executables_folder$elandtype NM\/$prefix\_$_\_norefs.NM $FindBin::Bin/filteringrefs/adapter NM\/$prefix\_$_\_adapter.elandout\n", 
+				"$eland_executables_folder$elandtype $outputdir\/NM\/$prefix\_$_\_norefs.NM $FindBin::Bin/filteringrefs/adapter $outputdir\/NM\/$prefix\_$_\_adapter.elandout\n", 
 			# Pass sequences that did not align to adapter reference to a new file (use as input for alignment to mouse)
 			# Also pass sequences that DID align to adapter reference to a new file
-				"$parse_script_path NM\/$prefix\_$_\_adapter.elandout NM\/$prefix\_$_\_noadapters.NM filteredseqs/adapter\/$prefix\_$_\_adapter.fna\n",
+				"$parse_script_path $outputdir\/NM\/$prefix\_$_\_adapter.elandout $outputdir\/NM\/$prefix\_$_\_noadapters.NM $outputdir\/filteredseqs/adapter\/$prefix\_$_\_adapter.fna\n",
 			# Align remaining sequences to mouse reference, allowing 2 mismatches
 			# Squashed mouse genome should be distributed with scripts
-				"$eland_executables_folder$elandtype NM\/$prefix\_$_\_noadapters.NM $FindBin::Bin/filteringrefs/mouse NM\/$prefix\_$_\_mouse.elandout\n",
+				"$eland_executables_folder$elandtype $outputdir\/NM\/$prefix\_$_\_noadapters.NM $FindBin::Bin/filteringrefs/mouse $outputdir\/NM\/$prefix\_$_\_mouse.elandout\n",
 			# Pass sequences that did not align to mouse reference to a new file (these will be the final, non-matching sequences of unknown origin)
 			# Also pass sequences that DID align to mouse reference to a new file
-				"$parse_script_path NM\/$prefix\_$_\_mouse.elandout filteredseqs/unknown\/$prefix\_$_\_unknown.fna filteredseqs/mouse\/$prefix\_$_\_mouse.fna\n",
+				"$parse_script_path $outputdir\/NM\/$prefix\_$_\_mouse.elandout $outputdir\/filteredseqs/unknown\/$prefix\_$_\_unknown.fna $outputdir\/filteredseqs/mouse\/$prefix\_$_\_mouse.fna\n",
 			# Create dummy .done file to record that all tasks are completed
-				"echo COMPLETE > NM\/$prefix\_$_\.done\n";
+				"echo COMPLETE > $outputdir\/NM\/$prefix\_$_\.done\n";
 		}
 		else {
                         print TASKSFORBC "#!/bin/bash\n";
 			print TASKSFORBC "echo Skipping alignments for barcode $_ because there were no sequences in your input file matching this barcode.\n";
 			# Create empty .elandout file so that progress monitoring doesn't break
 			print TASKSFORBC "touch $outputdir\/elandresults\/$prefix\_$_\.elandout\n";
-			print TASKSFORBC "echo COMPLETE > NM\/$prefix\_$_\.done\n";
+			print TASKSFORBC "echo COMPLETE > $outputdir\/NM\/$prefix\_$_\.done\n";
 		}
 		close TASKSFORBC;
 		# Append new jobs here with semicolons so that multiple tasks get passed to each node but are completed as a group
@@ -200,7 +200,7 @@ unless ($single_cpu) {
 		$num_finished = 0;
 		$num_notstarted = 0;
 		foreach (@barcodes) {
-			my $filestring = "NM\/$prefix\_$_\.done";
+			my $filestring = "$outputdir\/NM\/$prefix\_$_\.done";
 			my $statuscode = check_for_file($filestring);
 			if ($statuscode == 0) { $num_notstarted++; }
 			elsif ($statuscode == 1) { $num_running++; }


### PR DESCRIPTION
Hi Nate--

I noticed that when running the HTCF coproseq module with the output directory option, it failed since all of the NM directory references didn't have the output directory in front of them.  I've fixed this on top of the version Matt worked on to clean up some of the usage & options so it runs for me now.  Let me know if you have any questions.

Ashley

